### PR TITLE
Explicitly require evil

### DIFF
--- a/evil-quickscope.el
+++ b/evil-quickscope.el
@@ -62,6 +62,8 @@
 
 ;;; Code:
 
+(require 'evil)
+
 (defgroup evil-quickscope nil
   "Target highlighting for evil-mode's f,F,t,T keys."
   :group 'evil)


### PR DESCRIPTION
This ensures its macros are available while byte-compiling
